### PR TITLE
Fix usage example typos.

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -4,7 +4,7 @@
 const TabStops = require('tabstops');
 
 // pass a string as the first argument 
-const tabstops = new Tabstops('console.log("$1");');
+const tabstops = new TabStops('console.log("$1");');
 
 console.log(tabstops.render()); //=> 'console.log("");'
 
@@ -12,7 +12,7 @@ tabstops.set(1, 'It worked!');
 console.log(tabstops.render()); //=> 'console.log("It worked!");'
 
 tabstops.set(2, 'Warning!');
-console.log(tabstops.render()); //=> 'console.log("Warning!");'
+console.log(tabstops.render()); //=> 'console.log("It worked!");'
 ```
 
 ## Docs


### PR DESCRIPTION
Just a couple of typos in the usage example.